### PR TITLE
Value of constant should also be used in text message

### DIFF
--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -2,7 +2,7 @@
 
 class QSO extends CI_Controller {
 
-    const LAST_QSOS_COUNT = 5; // max number of most recent qsos to be displayed on a qso page
+	const LAST_QSOS_COUNT = 5; // max number of most recent qsos to be displayed on a qso page
 
 	function __construct()
 	{
@@ -85,6 +85,8 @@ class QSO extends CI_Controller {
 		} else {
 			$data['user_dok_to_qso_tab'] = 0;
 		}
+
+		$data['qso_count'] = self::LAST_QSOS_COUNT;
 
 		$this->load->library('form_validation');
 

--- a/application/views/qso/index.php
+++ b/application/views/qso/index.php
@@ -776,7 +776,7 @@
 
         </div>
       </div>
-      <small style="float: right;"><?= __("Max. 5 previous contacts are shown"); ?></small>
+      <small style="float: right;"><?= sprintf(__("Max. %s previous contacts are shown"), $qso_count); ?></small>
     </div>
   </div>
 


### PR DESCRIPTION
If we make the qso count a number we should use it in the text message saying how many QSOs are shown.